### PR TITLE
D8CORE-2614: removing the extra su-button class

### DIFF
--- a/modules/soe_paragraph_stories/config/install/core.entity_view_display.paragraph.stanford_stories.default.yml
+++ b/modules/soe_paragraph_stories/config/install/core.entity_view_display.paragraph.stanford_stories.default.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.stanford_stories.stanford_stories_border
     - field.field.paragraph.stanford_stories.stanford_stories_cta_link
     - field.field.paragraph.stanford_stories.stanford_stories_name
     - field.field.paragraph.stanford_stories.stanford_stories_node_link
     - field.field.paragraph.stanford_stories.stanford_stories_photo
-    - field.field.paragraph.stanford_stories.stanford_stories_border
     - field.field.paragraph.stanford_stories.stanford_stories_quote
     - field.field.paragraph.stanford_stories.stanford_stories_title
     - paragraphs.paragraphs_type.stanford_stories
@@ -42,11 +42,20 @@ third_party_settings:
         - stanford_stories_cta_link
       border_color_variant:
         - stanford_stories_border
+_core:
+  default_config_hash: 02O7gZXP9P8m2VofA9QrJ45HCimNF5Doy4bCTJgr8R8
 id: paragraph.stanford_stories.default
 targetEntityType: paragraph
 bundle: stanford_stories
 mode: default
 content:
+  stanford_stories_border:
+    type: list_key
+    weight: 6
+    region: border_color_variant
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   stanford_stories_cta_link:
     type: link
     weight: 5
@@ -60,7 +69,7 @@ content:
       target: '0'
     third_party_settings:
       field_formatter_class:
-        class: 'su-stories-paragraph__cta su-button'
+        class: su-stories-paragraph__cta
   stanford_stories_name:
     weight: 1
     label: hidden
@@ -97,13 +106,6 @@ content:
       field_formatter_class:
         class: su-stories-paragraph__photo
     region: image
-  stanford_stories_border:
-    type: list_key
-    weight: 6
-    region: border_color_variant
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
   stanford_stories_quote:
     type: text_default
     weight: 3
@@ -122,4 +124,3 @@ content:
       field_formatter_class:
         class: su-stories-paragraph__title
 hidden: {  }
-

--- a/modules/soe_paragraph_stories/config/install/core.entity_view_display.paragraph.stanford_stories.default.yml
+++ b/modules/soe_paragraph_stories/config/install/core.entity_view_display.paragraph.stanford_stories.default.yml
@@ -42,8 +42,6 @@ third_party_settings:
         - stanford_stories_cta_link
       border_color_variant:
         - stanford_stories_border
-_core:
-  default_config_hash: 02O7gZXP9P8m2VofA9QrJ45HCimNF5Doy4bCTJgr8R8
 id: paragraph.stanford_stories.default
 targetEntityType: paragraph
 bundle: stanford_stories


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed the hover on the button. There was an extra su-button class.

# Review By (Date)
- 9/25

# Criticality
- Med
- SOE

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Add a story with a CTA link
3. Verify there is only one hover and not two.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- SOE Paragraph Stories

# Associated Issues and/or People
- D8CORE-2614
- https://github.com/SU-SOE/soe_profile/pull/73

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
